### PR TITLE
Fix invalid gemspec

### DIFF
--- a/travis-assets.gemspec
+++ b/travis-assets.gemspec
@@ -1,5 +1,6 @@
 Gem::Specification.new do |s|
   s.name    = 'travis-assets'
   s.version = '0.0.1'
+  s.summary = 'Asset engine for Travis'
 end
 


### PR DESCRIPTION
The gemspec needs a `summary` field to be valid. `bundle install` in travis-ci
was complaining about it not being there. Now it is.
