### PR TITLE
Try to select the current branch in the toolbox for the build status images

### DIFF
--- a/assets/javascripts/app/controllers/repositories/show.js
+++ b/assets/javascripts/app/controllers/repositories/show.js
@@ -105,7 +105,9 @@ Travis.Controllers.Repositories.Show = Ember.Object.extend({
         // updated twice too.
         selector.empty();
         $.each(branches, function(index, branch) { $('<option>', { value: branch }).html(branch).appendTo(selector); });
-        selector.val('master');
+        // TODO: Select the current branch
+        var current_branch = Travis.main.get('build').get('branch');
+        selector.val(current_branch || 'master');
 
         this._updateStatusImageCodes();
       }.bind(this));


### PR DESCRIPTION
Requested by @vicb in travis-ci/travis-ci#381.

This is a pretty dumb way to do it, but it seems to work in most cases. If you switch to a special branch build, then back to the log of all builds, it doesn't change, but if you then move to a build that builds a different branch, it changes again.
