### PR TITLE
Make tools button clickable on narrow screens

### DIFF
--- a/assets/stylesheets/application.css.scss.erb
+++ b/assets/stylesheets/application.css.scss.erb
@@ -427,6 +427,7 @@ caption {
   .tools {
     position: relative;
     display: block;
+    z-index: 3;
     float: right;
     width: 39px;
     height: 21px;


### PR DESCRIPTION
1. Go to any travis-ci project page
2. Resize your browser window until the tools button (the button with the gear and the triangle) wraps to a different line than the tabs
3. The tools button is unclickable because the CSS rules for `#main .tabs .tab, .tabs .tab` give it a `z-index` of 1, which puts the content on top of the button.
